### PR TITLE
deploy snapshot as build artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: build for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        include:
+          - version: v5.6.2
+          - repository: https://github.com/potassco/clingo.git
+          - os: ubuntu-latest
+            lib: build/bin/libclingo.so
+            cfg: >
+              -DCMAKE_SHARED_LINKER_FLAGS="-static-libgcc -static-libstdc++"
+          - os: windows-latest
+            lib: build/bin/Release/clingo.dll
+            bld: >
+              --config Release
+          - os: macos-latest
+            lib: build/bin/libclingo.dylib
+            cfg: >
+              -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+
+    steps:
+    - name: clone
+      run: git clone --depth 1 --branch ${{ matrix.version }} ${{ matrix.repository }} source
+
+    - name: configure
+      run: >
+        cmake -S source -B build
+        -DCMAKE_BUILD_TYPE=release
+        -DCLINGO_BUILD_WITH_PYTHON=off
+        -DCLINGO_BUILD_WITH_LUA=off
+        ${{ matrix.cfg }}
+
+    - name: build
+      run: >
+        cmake --build build --target libclingo -j 2
+        ${{ matrix.bld }}
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: artifact
+        path: ${{ matrix.lib }}
+
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: src/main/resources
+
+    - name: build
+      run: mvn package
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: jar
+        path: target/*.jar


### PR DESCRIPTION
@kherud, I found some time to automate the build process of the jar. It includes libraries for linux, macos, and windows. A snapshot is build whenever something is committed to the master.

From here it would also be easy to deploy the jar somewhere. I have no experience with this however. Maybe one could bundle all dependencies in the jar or upload it to some registry in case there is a release. If you send me the required commands, I could extend the workflow.

Also interesting: https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven